### PR TITLE
Fix using dev container in custom subfolder

### DIFF
--- a/envbuilder.go
+++ b/envbuilder.go
@@ -407,6 +407,7 @@ func Run(ctx context.Context, options Options) error {
 		if !filepath.IsAbs(devcontainerPath) {
 			devcontainerPath = filepath.Join(devcontainerDir, devcontainerPath)
 		}
+		devcontainerDir = filepath.Dir(devcontainerPath)
 		_, err := options.Filesystem.Stat(devcontainerPath)
 		if err == nil {
 			// We know a devcontainer exists.

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -112,10 +112,16 @@ type Options struct {
 	// It will override CacheRepo if both are specified.
 	LayerCacheDir string `env:"LAYER_CACHE_DIR"`
 
-	// DevcontainerJSONPath is a relative or absolute path to a
-	// devcontainer.json file. This can be used in cases where
-	// one wants to substitute an edited devcontainer.json file
-	// for the one that exists in the repo.
+	// DevcontainerDir is a relative path to the folder containing
+	// the devcontainer.json file that will be used to build the
+	// workspace. If not provided, defaults to `.devcontainer`.
+	DevcontainerDir string `env:"DEVCONTAINER_DIR"`
+
+	// DevcontainerJSONPath is a path to a devcontainer.json file
+	// that is either an absolute path or a path relative to
+	// DevcontainerDir. This can be used in cases where one wants
+	// to substitute an edited devcontainer.json file for the one
+	// that exists in the repo.
 	DevcontainerJSONPath string `env:"DEVCONTAINER_JSON_PATH"`
 
 	// DockerfilePath is a relative path to the Dockerfile that
@@ -399,7 +405,11 @@ func Run(ctx context.Context, options Options) error {
 	if options.DockerfilePath == "" {
 		// Only look for a devcontainer if a Dockerfile wasn't specified.
 		// devcontainer is a standard, so it's reasonable to be the default.
-		devcontainerDir := filepath.Join(options.WorkspaceFolder, ".devcontainer")
+		devcontainerDir := options.DevcontainerDir
+		if devcontainerDir == "" {
+			devcontainerDir = ".devcontainer"
+		}
+		devcontainerDir = filepath.Join(options.WorkspaceFolder, devcontainerDir)
 		devcontainerPath := options.DevcontainerJSONPath
 		if devcontainerPath == "" {
 			devcontainerPath = "devcontainer.json"
@@ -407,7 +417,6 @@ func Run(ctx context.Context, options Options) error {
 		if !filepath.IsAbs(devcontainerPath) {
 			devcontainerPath = filepath.Join(devcontainerDir, devcontainerPath)
 		}
-		devcontainerDir = filepath.Dir(devcontainerPath)
 		_, err := options.Filesystem.Stat(devcontainerPath)
 		if err == nil {
 			// We know a devcontainer exists.

--- a/envbuilder.go
+++ b/envbuilder.go
@@ -112,9 +112,11 @@ type Options struct {
 	// It will override CacheRepo if both are specified.
 	LayerCacheDir string `env:"LAYER_CACHE_DIR"`
 
-	// DevcontainerDir is a relative path to the folder containing
+	// DevcontainerDir is a path to the folder containing
 	// the devcontainer.json file that will be used to build the
-	// workspace. If not provided, defaults to `.devcontainer`.
+	// workspace and can either be an absolute path or a path
+	// relative to the workspace folder. If not provided, defaults to
+	// `.devcontainer`.
 	DevcontainerDir string `env:"DEVCONTAINER_DIR"`
 
 	// DevcontainerJSONPath is a path to a devcontainer.json file
@@ -409,7 +411,9 @@ func Run(ctx context.Context, options Options) error {
 		if devcontainerDir == "" {
 			devcontainerDir = ".devcontainer"
 		}
-		devcontainerDir = filepath.Join(options.WorkspaceFolder, devcontainerDir)
+		if !filepath.IsAbs(devcontainerDir) {
+			devcontainerDir = filepath.Join(options.WorkspaceFolder, devcontainerDir)
+		}
 		devcontainerPath := options.DevcontainerJSONPath
 		if devcontainerPath == "" {
 			devcontainerPath = "devcontainer.json"

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -208,6 +208,31 @@ func TestBuildWithSetupScript(t *testing.T) {
 	require.Equal(t, "hi", strings.TrimSpace(output))
 }
 
+func TestBuildFromDevcontainerInCustomPath(t *testing.T) {
+	t.Parallel()
+
+	// Ensures that a Git repository with a devcontainer.json is cloned and built.
+	url := createGitServer(t, gitServerOptions{
+		files: map[string]string{
+			".devcontainer/custom/devcontainer.json": `{
+				"name": "Test",
+				"build": {
+					"dockerfile": "Dockerfile"
+				},
+			}`,
+			".devcontainer/custom/Dockerfile": "FROM ubuntu",
+		},
+	})
+	ctr, err := runEnvbuilder(t, options{env: []string{
+		"GIT_URL=" + url,
+		"DEVCONTAINER_JSON_PATH=custom/devcontainer.json",
+	}})
+	require.NoError(t, err)
+
+	output := execContainer(t, ctr, "echo hello")
+	require.Equal(t, "hello", strings.TrimSpace(output))
+}
+
 func TestBuildCustomCertificates(t *testing.T) {
 	srv := httptest.NewTLSServer(createGitHandler(t, gitServerOptions{
 		files: map[string]string{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -225,7 +225,7 @@ func TestBuildFromDevcontainerInCustomPath(t *testing.T) {
 	})
 	ctr, err := runEnvbuilder(t, options{env: []string{
 		"GIT_URL=" + url,
-		"DEVCONTAINER_JSON_PATH=custom/devcontainer.json",
+		"DEVCONTAINER_DIR=.devcontainer/custom",
 	}})
 	require.NoError(t, err)
 


### PR DESCRIPTION
I noticed that using `DEVCONTAINER_JSON_PATH` to configure a custom path to `devcontainer.json` relative to the root `.devcontainer` folder of a repo (e.g. `.devcontainer/my_custom_subfolder/devcontainer.json`) would fail because `envbuilder` would still try to compile the dev container using `.devcontainer` instead of the custom subfolder containing `devcontainer.json`, and meanwhile the `build.Dockerfile` property within `devcontainer.json` [expects](https://containers.dev/implementors/json_reference/#image-specific:~:text=The%20path%20is%20relative%20to%20the%20devcontainer.json%20file.) the provided `Dockerfile` path to be relative to the `devcontainer.json` file which may not be directly under `.devcontainer` if `DEVCONTAINER_JSON_PATH` is configured.

This is the scenario referred to by the third bullet point described here: https://containers.dev/implementors/spec/#devcontainerjson

> Products using it should expect to find a devcontainer.json file in one or more of the following locations (in order of precedence):
> * `.devcontainer/devcontainer.json`
> * `.devcontainer.json`
> * `.devcontainer/<folder>/devcontainer.json` (where `<folder>` is a sub-folder, one level deep)

I wrote a new integration test that surfaces this problem, and before the included fix it failed as expected with:

```
--- FAIL: TestBuildFromDevcontainerInCustomPath (0.22s)
    integration_test.go:813: "\x1b[1menvbuilder\x1b[0m - Build development environments from repositories in a container"
    integration_test.go:813: "#1: 📦 Cloning \x1b[36mhttp://127.0.0.1:41911\x1b[0m to \x1b[36m/workspaces/\x1b[0m..."
    integration_test.go:813: "#1: 📦 Cloned repository! [5.771923ms]"
    integration_test.go:813: "error: compile devcontainer.json: open dockerfile \"/workspaces/.devcontainer/Dockerfile\": open /workspaces/.devcontainer/Dockerfile: no such file or directory"
    integration_test.go:230: 
        	Error Trace:	/home/runner/work/envbuilder/envbuilder/integration/integration_test.go:230
        	Error:      	Received unexpected error:
        	            	error: compile devcontainer.json: open dockerfile "/workspaces/.devcontainer/Dockerfile": open /workspaces/.devcontainer/Dockerfile: no such file or directory
        	Test:       	TestBuildFromDevcontainerInCustomPath
FAIL
FAIL	github.com/coder/envbuilder/integration	85.839s
```

With the included fix, the new integration test now passes.