### PR TITLE
Fix building features that call bundled scripts

### DIFF
--- a/devcontainer/devcontainer_test.go
+++ b/devcontainer/devcontainer_test.go
@@ -91,19 +91,21 @@ func TestCompileWithFeatures(t *testing.T) {
 
 	// We have to SHA because we get a different MD5 every time!
 	featureOneMD5 := md5.Sum([]byte(featureOne))
-	featureOneSha := fmt.Sprintf("%x", featureOneMD5[:4])
+	featureOneDir := fmt.Sprintf(".envbuilder/features/one-%x", featureOneMD5[:4])
 	featureTwoMD5 := md5.Sum([]byte(featureTwo))
-	featureTwoSha := fmt.Sprintf("%x", featureTwoMD5[:4])
+	featureTwoDir := fmt.Sprintf(".envbuilder/features/two-%x", featureTwoMD5[:4])
 
 	require.Equal(t, `FROM codercom/code-server:latest
 
 USER root
 # Rust tomato - Example description!
+WORKDIR `+featureOneDir+`
 ENV TOMATO=example
-RUN .envbuilder/features/one-`+featureOneSha+`/install.sh
+RUN ./install.sh
 # Go potato - Example description!
+WORKDIR `+featureTwoDir+`
 ENV POTATO=example
-RUN VERSION=potato .envbuilder/features/two-`+featureTwoSha+`/install.sh
+RUN VERSION=potato ./install.sh
 USER 1000`, params.DockerfileContent)
 }
 

--- a/devcontainer/features/features.go
+++ b/devcontainer/features/features.go
@@ -205,7 +205,7 @@ func (s *Spec) Compile(options map[string]any) (string, error) {
 	if comment != "" {
 		lines = append(lines, comment)
 	}
-	lines = append(lines, fmt.Sprintf("WORKDIR %s", s.Directory))
+	lines = append(lines, "WORKDIR "+s.Directory)
 	envKeys := make([]string, 0, len(s.ContainerEnv))
 	for key := range s.ContainerEnv {
 		envKeys = append(envKeys, key)

--- a/devcontainer/features/features_test.go
+++ b/devcontainer/features/features_test.go
@@ -81,28 +81,28 @@ func TestCompile(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 		spec := &features.Spec{
-			InstallScriptPath: "install.sh",
+			Directory: "/",
 		}
 		directive, err := spec.Compile(nil)
 		require.NoError(t, err)
-		require.Equal(t, "RUN install.sh", strings.TrimSpace(directive))
+		require.Equal(t, "WORKDIR /\nRUN ./install.sh", strings.TrimSpace(directive))
 	})
 	t.Run("ContainerEnv", func(t *testing.T) {
 		t.Parallel()
 		spec := &features.Spec{
-			InstallScriptPath: "install.sh",
+			Directory: "/",
 			ContainerEnv: map[string]string{
 				"FOO": "bar",
 			},
 		}
 		directive, err := spec.Compile(nil)
 		require.NoError(t, err)
-		require.Equal(t, "ENV FOO=bar\nRUN install.sh", strings.TrimSpace(directive))
+		require.Equal(t, "WORKDIR /\nENV FOO=bar\nRUN ./install.sh", strings.TrimSpace(directive))
 	})
 	t.Run("OptionsEnv", func(t *testing.T) {
 		t.Parallel()
 		spec := &features.Spec{
-			InstallScriptPath: "install.sh",
+			Directory: "/",
 			Options: map[string]features.Option{
 				"foo": {
 					Default: "bar",
@@ -111,6 +111,6 @@ func TestCompile(t *testing.T) {
 		}
 		directive, err := spec.Compile(nil)
 		require.NoError(t, err)
-		require.Equal(t, "RUN FOO=bar install.sh", strings.TrimSpace(directive))
+		require.Equal(t, "WORKDIR /\nRUN FOO=bar ./install.sh", strings.TrimSpace(directive))
 	})
 }


### PR DESCRIPTION
Some dev container features call bundled scripts from `install.sh`. For example, the `ghcr.io/devcontainers-contrib/features/fzf` feature bundles a `library_scripts.sh` script which it sources from `install.sh` here:

https://github.com/devcontainers-contrib/features/blob/ad7221270c9ff489304ff061bc2903cc1db163bb/src/fzf/install.sh#L4

I believe this assumes/requires that the `install.sh` script be invoked with a working directory of the folder containing `install.sh`. I couldn't find that behavior mentioned explicitly in the dev container spec, but I think it may be implied in this  [statement](https://containers.dev/implementors/features/#invoking-installsh:~:text=To%20ensure%20that%20the%20appropriate%20shell%20is%20used%2C%20the%20execute%20bit%20should%20be%20set%20on%20install.sh%20and%20the%20file%20invoked%20directly%20(e.g.%20chmod%20%2Bx%20install.sh%20%26%26%20./install.sh).):

> To ensure that the appropriate shell is used, the execute bit should be set on install.sh and the file invoked directly (e.g. chmod +x install.sh && ./install.sh).

Trying to build a dev container with `envbuilder` that builds the `ghcr.io/devcontainers-contrib/features/fzf` feature fails at the moment with:

```
#2: USER root
#2: Cmd: USER
#2: No files changed in this command, skipping snapshotting.
#2: RUN VERSION=latest .envbuilder/features/fzf-04efcc1c/install.sh
#2: Cmd: /bin/sh
#2: Args: [-c VERSION=latest .envbuilder/features/fzf-04efcc1c/install.sh]
#2: Util.Lookup returned: &{Uid:0 Gid:0 Username:root Name:root HomeDir:/root}
#2: Performing slow lookup of group ids for root
#2: Running: [/bin/sh -c VERSION=latest .envbuilder/features/fzf-04efcc1c/install.sh]
.envbuilder/features/fzf-04efcc1c/install.sh: 4: .: Can't open ./library_scripts.sh
Failed to build: error building stage: failed to execute command: waiting for process to exit: exit status 127
```

This PR fixes that issue by ensuring we switch to the feature directory before invoking `install.sh`.